### PR TITLE
Improve serialization formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,16 @@ version = "0.0.1"
 dependencies = [
  "float_eq",
  "nom",
+ "pretty_assertions",
  "thiserror",
  "utm",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "float_eq"
@@ -38,6 +45,16 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
 ]
 
 [[package]]
@@ -100,3 +117,9 @@ name = "utm"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95b09e3b3a0abd1ccb77673a6b7b8875d9d1c80626154add451cf18392dc4c3c"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ thiserror = "1.0.29"
 
 [dev-dependencies]
 float_eq = "1"
+pretty_assertions = "1.4.0"

--- a/src/survey/mod.rs
+++ b/src/survey/mod.rs
@@ -23,13 +23,8 @@ pub struct Parameters {
 }
 
 impl Parameters {
-    // TODO: this is probably the where I need to enforce column widths and such
-    // Some general things:
-    // 1. overall Rust review
-    // 2. look at docs / samples to understand constraints
     fn serialize(&self) -> String {
         let mut result = String::new();
-        // TODO: we might be missing FORMAT
         result.push_str(&format!("DECLINATION:   {:>4.2}  ", self.declination));
         if let Some(correction_factors) = &self.correction_factors {
             result.push_str(&format!(

--- a/src/survey/mod.rs
+++ b/src/survey/mod.rs
@@ -30,7 +30,7 @@ impl Parameters {
     fn serialize(&self) -> String {
         let mut result = String::new();
         // TODO: we might be missing FORMAT
-        result.push_str(&format!("DECLINATION: {:>4.2}  ", self.declination));
+        result.push_str(&format!("DECLINATION:   {:>4.2}  ", self.declination));
         if let Some(correction_factors) = &self.correction_factors {
             result.push_str(&format!(
                 "CORRECTIONS:  {:.2} {:.2} {:.2}",
@@ -76,19 +76,6 @@ pub struct Survey {
     pub shots: Vec<Shot>,
 }
 
-// TODO: maybe a little format module
-fn show_float64(f: f64) -> String {
-    format!("{:>4.2}", f)
-}
-
-fn show_string(s: String) -> String {
-    // way too many copies here
-    let mut c = s.clone();
-    c.truncate(8);
-
-    return c.trim().to_string();
-}
-
 impl Survey {
     /// Parse a survey from a string
     /// # Arguments
@@ -120,19 +107,7 @@ impl Survey {
 
     #[must_use]
     pub fn serialize(&self) -> String {
-        // Some comments:
-        // It looks like Rust's formatting doesn't let you specify what I would
-        // call significant digits, only number of digits past the decimal point.
-        // I *think* this is an issue since I think we want to 0 pad, but maybe
-        // we just need to align on a width, which Rust does let you do
-        //
-        // Anyway, constraints I know about:
-        // Numbers have 4 SD and 2 decimal points
-        // Names get truncated to 12 characters or something?
-        //
-        // All of this is in the sample project / documentation, will get precise answers later
         let mut result = String::new();
-        // let truncy = show_string(self.cave_name);
         result.push_str(&format!("{}\r\n", self.cave_name));
         result.push_str(&format!("SURVEY NAME: {}\n", self.name));
         result.push_str(&format!(
@@ -144,15 +119,13 @@ impl Survey {
         } else {
             result.push_str("\r\n");
         }
-        result.push_str("SURVEY TEAM:\r\n");
+        result.push_str("SURVEY TEAM: \r\n");
         result.push_str(&format!("{}\r\n", self.team));
-        // TODO: fuss around with this one
         result.push_str(&self.parameters.serialize());
-        result.push_str("\n         FROM           TO   LENGTH  BEARING      INC     LEFT       UP     DOWN    RIGHT   FLAGS  COMMENTS\n\n");
+        result.push_str("\n        FROM           TO   LENGTH  BEARING      INC     LEFT       UP     DOWN    RIGHT   FLAGS  COMMENTS\n\n");
         for shot in &self.shots {
-            // TODO: need to align these to end of their column names
             result.push_str(&format!(
-                "{:>13}{:>13}{:>9.2}{:>9.2}{:>9.2}{:>9.2}{:>9.2}{:>9.2}{:>9.2}\n",
+                "{:>12}{:>13}{:>9.2}{:>9.2}{:>9.2}{:>9.2}{:>9.2}{:>9.2}{:>9.2}\n",
                 shot.from,
                 shot.to,
                 shot.length,

--- a/src/survey/parser.rs
+++ b/src/survey/parser.rs
@@ -191,27 +191,9 @@ mod test {
                     survey.serialize().trim().replace("\r\n", "\n"),
                     perfection.trim()
                 );
+
+                break;
             }
         }
     }
-
-    // fn parse_example_data() {
-    //     let input = include_str!("../../test_data/Fulford.dat");
-    //     let (_input, _surveys) = many0(parse_survey)(input).unwrap();
-
-    //     // let mut file = OpenOptions::new().write(true).open("/tmp/survey").unwrap();
-    //     let mut file = File::create("/tmp/survey").unwrap();
-
-    //     for (_, survey) in _surveys.iter().enumerate() {
-    //         // writeln!(file, "{}", survey.serialize()).expect("Unable to write file");
-    //         file.write_all(survey.serialize().as_bytes())
-    //             .expect("Unable to write file");
-    //         // println!("{}", survey.serialize());
-
-    //         // fs::write(format!("/tmp/survey_{}", pos), survey.serialize())
-    //         //     .expect("Unable to write file!");
-    //     }
-
-    //     assert!(false);
-    // }
 }

--- a/src/survey/parser.rs
+++ b/src/survey/parser.rs
@@ -178,9 +178,9 @@ mod test {
     #[test]
     fn parse_example_data() {
         let input = include_str!("../../test_data/Fulford.dat");
-        let (_input, _surveys) = many0(parse_survey)(input).unwrap();
+        let (_input, surveys) = many0(parse_survey)(input).unwrap();
 
-        for survey in _surveys.iter() {
+        for survey in &surveys {
             // We have at least one gap in the serialization (FORMAT), so for now just do a test
             // against a simplified survey
             // Eventually we should be able to just do

--- a/src/survey/parser.rs
+++ b/src/survey/parser.rs
@@ -12,12 +12,6 @@ use crate::{
     parser_utils::{parse_double, parse_station_name, parse_uint, recognize_line, ws},
 };
 
-use std::fs;
-use std::fs::File;
-use std::fs::OpenOptions;
-use std::io::prelude::*;
-use std::process::ExitCode;
-
 use super::{BackSightCorrectionFactors, CorrectionFactors, Parameters, Shot, Survey};
 
 fn parse_cave_name(input: &str) -> IResult<&str, String> {
@@ -179,24 +173,45 @@ pub fn parse_dat_file(input: &str) -> IResult<&str, Vec<Survey>> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use pretty_assertions::assert_str_eq;
+
     #[test]
     fn parse_example_data() {
         let input = include_str!("../../test_data/Fulford.dat");
         let (_input, _surveys) = many0(parse_survey)(input).unwrap();
 
-        // let mut file = OpenOptions::new().write(true).open("/tmp/survey").unwrap();
-        let mut file = File::create("/tmp/survey").unwrap();
-
-        for (_, survey) in _surveys.iter().enumerate() {
-            // writeln!(file, "{}", survey.serialize()).expect("Unable to write file");
-            file.write_all(survey.serialize().as_bytes())
-                .expect("Unable to write file");
-            // println!("{}", survey.serialize());
-
-            // fs::write(format!("/tmp/survey_{}", pos), survey.serialize())
-            //     .expect("Unable to write file!");
+        for survey in _surveys.iter() {
+            // We have at least one gap in the serialization (FORMAT), so for now just do a test
+            // against a simplified survey
+            // Eventually we should be able to just do
+            // `assert_str_eq!(survey.serialize(), input)`
+            if survey.name == "CL" {
+                let perfection = include_str!("../../test_data/fulford_cave_survey.dat").trim();
+                assert_str_eq!(
+                    survey.serialize().trim().replace("\r\n", "\n"),
+                    perfection.trim()
+                );
+            }
         }
-
-        assert!(false);
     }
+
+    // fn parse_example_data() {
+    //     let input = include_str!("../../test_data/Fulford.dat");
+    //     let (_input, _surveys) = many0(parse_survey)(input).unwrap();
+
+    //     // let mut file = OpenOptions::new().write(true).open("/tmp/survey").unwrap();
+    //     let mut file = File::create("/tmp/survey").unwrap();
+
+    //     for (_, survey) in _surveys.iter().enumerate() {
+    //         // writeln!(file, "{}", survey.serialize()).expect("Unable to write file");
+    //         file.write_all(survey.serialize().as_bytes())
+    //             .expect("Unable to write file");
+    //         // println!("{}", survey.serialize());
+
+    //         // fs::write(format!("/tmp/survey_{}", pos), survey.serialize())
+    //         //     .expect("Unable to write file!");
+    //     }
+
+    //     assert!(false);
+    // }
 }

--- a/src/survey/parser.rs
+++ b/src/survey/parser.rs
@@ -12,6 +12,12 @@ use crate::{
     parser_utils::{parse_double, parse_station_name, parse_uint, recognize_line, ws},
 };
 
+use std::fs;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::prelude::*;
+use std::process::ExitCode;
+
 use super::{BackSightCorrectionFactors, CorrectionFactors, Parameters, Shot, Survey};
 
 fn parse_cave_name(input: &str) -> IResult<&str, String> {
@@ -177,5 +183,20 @@ mod test {
     fn parse_example_data() {
         let input = include_str!("../../test_data/Fulford.dat");
         let (_input, _surveys) = many0(parse_survey)(input).unwrap();
+
+        // let mut file = OpenOptions::new().write(true).open("/tmp/survey").unwrap();
+        let mut file = File::create("/tmp/survey").unwrap();
+
+        for (_, survey) in _surveys.iter().enumerate() {
+            // writeln!(file, "{}", survey.serialize()).expect("Unable to write file");
+            file.write_all(survey.serialize().as_bytes())
+                .expect("Unable to write file");
+            // println!("{}", survey.serialize());
+
+            // fs::write(format!("/tmp/survey_{}", pos), survey.serialize())
+            //     .expect("Unable to write file!");
+        }
+
+        assert!(false);
     }
 }

--- a/test_data/fulford_cave_survey.dat
+++ b/test_data/fulford_cave_survey.dat
@@ -1,0 +1,14 @@
+Fulford Cave
+SURVEY NAME: CL
+SURVEY DATE: 6 10 1989  COMMENT:Moon Milk Side Passage
+SURVEY TEAM: 
+Steve Reames,Paul Burger,Stan Allison,Dave Fazzina,
+DECLINATION:   11.18  CORRECTIONS:  0.00 0.00 0.00
+
+        FROM           TO   LENGTH  BEARING      INC     LEFT       UP     DOWN    RIGHT   FLAGS  COMMENTS
+
+         CA3          CL1    16.25    93.00    31.50 -9999.00 -9999.00 -9999.00 -9999.00
+         CL1          CL2    12.70   199.00     0.00 -9999.00 -9999.00 -9999.00 -9999.00
+         CL2          CL3    15.45   138.50     0.00 -9999.00 -9999.00 -9999.00 -9999.00
+         CL3          CL4    14.75   163.50    21.50 -9999.00 -9999.00 -9999.00 -9999.00
+         CL4          C15    12.50   217.50     8.00 -9999.00 -9999.00 -9999.00 -9999.00


### PR DESCRIPTION
This just tweaks some of the serialization output to be more columnar.

Also adds a new crate that does some nice `diff`-y string eq assertions: https://docs.rs/pretty_assertions/latest/pretty_assertions/

---

![image](https://github.com/user-attachments/assets/2d909ea8-a17e-4369-a9aa-c364db092067)
